### PR TITLE
Upgrade Newtonsoft Json to 13.0.2

### DIFF
--- a/src/GraphQL.Client.LocalExecution/GraphQL.Client.LocalExecution.csproj
+++ b/src/GraphQL.Client.LocalExecution/GraphQL.Client.LocalExecution.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="GraphQL.MicrosoftDI" Version="4.6.1" />
     <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.6.0" />
     <PackageReference Include="GraphQL.SystemReactive" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Client.Serializer.Newtonsoft/GraphQL.Client.Serializer.Newtonsoft.csproj
+++ b/src/GraphQL.Client.Serializer.Newtonsoft/GraphQL.Client.Serializer.Newtonsoft.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For whatever reason, worklink-app currently points to the branch use_unirx-2.  Not anything main-sounding like master.  We don't have a great branching structure for our fork of this repo.

Target this branch with this PR?  Rename it later?